### PR TITLE
feat: add depth=1 option to speedup repo clone

### DIFF
--- a/src/dclone.ts
+++ b/src/dclone.ts
@@ -19,7 +19,7 @@ const execWithPromise = promisify(exec)
 
 const cloneRoot = async (rootDir: string) => {
   return new Promise(resolve => {
-    const child = spawn('git', ['clone', `${rootDir}.git`], {
+    const child = spawn('git', ['clone', '--depth=1', `${rootDir}.git`], {
       stdio: 'inherit'
     })
     child.on('stdout', data => {


### PR DESCRIPTION
Add git clone option `--depth=1`，which allowing git only fetch the minimum required commits for lastest version of current `main` branch. 

It will save lots of repo downloading time.